### PR TITLE
Handle Twelve Data API key errors and fix technical analysis lookup

### DIFF
--- a/technical_analysis.py
+++ b/technical_analysis.py
@@ -43,6 +43,9 @@ def get_historical_data(ticker: str, interval: str = 'day', span: str = '3month'
         # Filter out None values and convert price strings to floats
         clean_data = []
         for data_point in historical_data:
+            if not isinstance(data_point, dict):
+                continue
+
             if all(data_point.get(key) is not None for key in ['open_price', 'high_price', 'low_price', 'close_price']):
                 try:
                     clean_point = {


### PR DESCRIPTION
## Summary
- normalize and validate the Twelve Data API key configuration, halting live requests when the key is missing or rejected and falling back to mock data with guidance logs
- call technical analysis routines with ticker symbols and harden historical data parsing against stray `None` entries

## Testing
- python -m compileall stock_prices.py technical_analysis.py

------
https://chatgpt.com/codex/tasks/task_e_68d57adfc28c832ca7102af9342fb6e1