### PR TITLE
Restore Twelve Data rate limiter configuration

### DIFF
--- a/config.example.py
+++ b/config.example.py
@@ -14,5 +14,11 @@ ROBINHOOD_PASSWORD = "your_password"
 # Set as environment variable: export TWELVEDATA_API_KEY=your_api_key
 TWELVEDATA_API_KEY = "your_twelvedata_api_key"
 
+# Optional: Override Twelve Data rate limiting defaults (free tier: 8 req/min)
+# export TWELVEDATA_REQUESTS_PER_MINUTE=8
+# export TWELVEDATA_COOLDOWN_SECONDS=15
+# TWELVEDATA_REQUESTS_PER_MINUTE = 8
+# TWELVEDATA_COOLDOWN_SECONDS = 15
+
 # Path to Excel file containing tickers (must have 'Ticker' column)
 TICKERS_FILE = "tickers.xlsx"


### PR DESCRIPTION
## Summary
- reintroduce a reusable rate limiter with cooldown handling for Twelve Data API requests and allow configuration through environment variables
- wire the rate limiter into the technical indicators extractor to pause on HTTP 429 responses and throttling messages
- document optional Twelve Data rate limit overrides in `config.example.py`

## Testing
- python -m compileall technical_indicators_extractor.py config.example.py

------
https://chatgpt.com/codex/tasks/task_e_68d5817b8318832c997210ed32fb3b46